### PR TITLE
fix(evalVarStageExecution): In restart scenario variables are reset

### DIFF
--- a/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
+++ b/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/EvaluateVariablesStage.java
@@ -50,6 +50,22 @@ public class EvaluateVariablesStage extends ExpressionAwareStageDefinitionBuilde
   }
 
   @Override
+  public void prepareStageForRestart(@Nonnull StageExecution stage) {
+    stage.getOutputs().clear();
+    EvaluateVariablesStageContext context = stage.mapTo(EvaluateVariablesStageContext.class);
+
+    List<Variable> variables =
+        Optional.ofNullable(context.getVariables()).orElse(Collections.emptyList());
+    for (Variable var : variables) {
+      if (var.sourceExpression instanceof String) {
+        var.value = var.sourceExpression.toString().replace("{", "${");
+        var.sourceExpression = null;
+      }
+    }
+    stage.getContext().put("variables", variables);
+  }
+
+  @Override
   public boolean processExpressions(
       @Nonnull StageExecution stage,
       @Nonnull ContextParameterProcessor contextParameterProcessor,

--- a/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
+++ b/orca-core/src/test/groovy/com/netflix/spinnaker/orca/pipeline/tasks/EvaluateVariablesStageSpec.groovy
@@ -81,4 +81,29 @@ class EvaluateVariablesStageSpec extends Specification {
     shouldContinue == false
     stage.context.notifications[0].address == "someone@somewhere.com"
   }
+
+  void "Should correctly clean variables in restart scenario"() {
+    setup:
+    def summary = new ExpressionEvaluationSummary()
+
+    def stage = stage {
+      refId = "1"
+      type = "evaluateVariables"
+      context["variables"] = [
+          ["key": "status", "value": "expressionToEvaluate"],
+      ]
+    }
+
+    when:
+    evaluateVariablesStage.processExpressions(stage, contextParameterProcessor, summary)
+    evaluateVariablesStage.prepareStageForRestart(stage)
+    def variables = stage.mapTo(EvaluateVariablesStage.EvaluateVariablesStageContext.class).getVariables()
+    def variablesCleaned = false
+    variables.each {
+      variablesCleaned = it.sourceExpression == null
+    }
+
+    then:
+    variablesCleaned == true
+  }
 }


### PR DESCRIPTION
Issue: Expression evaluates the previous data when upstream stage(Manual Judgement) is restarted (or other restar case).
![image](https://user-images.githubusercontent.com/21283264/192370324-c31fe727-5f80-448f-8b27-5322fd4b9642.png)


Steps to reproduce:
1. Execute the pipeline and choose Continue at the Manual Judgement stage. Upon completion note that the status variable inside "Evaluate Variables" was evaluated to 'success'; this is correct. 

2. Execute the pipeline again and when it reaches the Manual Judgment, wait 1 min for it to timeout or stop manually the judgment. Upon timeout, note that the status variable inside "Evaluate Variables" was evaluated to 'failed'; again this is correct. 

3. Click on the failed Manual Judgment stage and choose Actions -> Restart Manual Judgement from the drop down.  
The pipeline will execute. Choose Continue for the Manual Judgement. Upon completion note that the status variable inside "Evaluate Variables" has still evaluated to 'failed'; this is incorrect as the deploy stage was successful. 

Solution:
EvaluateVariablesStage does not have logic created for restart scenarios, so the values for the expression previously executed are preserved. 

prepareStageForRestart function for EvaluateVariablesStage object needs clear the values for a new execution.

Scenario whit approach applied:

![image](https://user-images.githubusercontent.com/21283264/192370407-f1c6b317-0ca1-45bc-b06f-b7155e8f72b0.png)
